### PR TITLE
poprawione colapsowanie jokerow jesli nie sa obok siebie

### DIFF
--- a/parsers/pajtonparser/tadpole/pond.py
+++ b/parsers/pajtonparser/tadpole/pond.py
@@ -131,6 +131,7 @@ class PondParser:
                         start, end = int(start), int(end)
                         prot = prot.split(";", maxsplit=1)[0].lstrip("ID=")
                         phrogs = self.map[prot]
+                        strand = Strand.into(strand)
                         if not phrogs:
                             phrogs = ["joker"]
 


### PR DESCRIPTION
# Zrobione
```
paragraph[i] = list(dict.fromkeys(paragraph[i]))
```
Zamienione na:
```
prev = object()
paragraph[i] = [prev := x for x in paragraph[i] if prev != x]
``` 
To poprawia usuwanie duplikatów znajdujacych sie przy sobie, a nie wszystkich.

# Kolejne
```
strand = Strand.into(strand)
```
Poprawia porownywanie enumow i likwiduje błąd
