### PR TITLE
added: script to make smaller subsets of phrogs and gffs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,22 @@
+# Scripts
+Collection of scripts helpful during the project.
+
+## make_subset.py
+
+Creates a smaller subset of phrogs and gffs. Helpful for testing around.
+
+### usage:
+```bash
+/m/t/p/p/data ❯ ./make_subset.py phrog gff 420
+420/420
+created: subset_of_420
+```
+
+### outcome:
+```text
+/m/t/p/p/data ❯ ls subset_of_420/phrog | wc                                                                                                                                              
+    420     420    5577
+/m/t/p/p/data ❯ ls subset_of_420/gff | wc
+    420     420    5577
+```
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,4 +19,36 @@ created: subset_of_420
 /m/t/p/p/data ❯ ls subset_of_420/gff | wc
     420     420    5577
 ```
+### seed
+seed is saved; and can be provided for reproducible results
 
+```text
+~/m/T/scripts ❯ ./make_subset.py $PHROG_DIR $GFF_DIR 2 -s 2022 && mv subset_of_2 sub0seed2022
+~/m/T/scripts ❯ ./make_subset.py $PHROG_DIR $GFF_DIR 2 -s 2022 && mv subset_of_2 sub1seed2022
+~/m/T/scripts ❯ ./make_subset.py $PHROG_DIR $GFF_DIR 2 && mv subset_of_2 subseedrandom
+~/m/T/scripts ❯ tree sub*
+sub0seed2022
+├── gff
+│   ├── MT680615.gff
+│   └── OM818327.gff
+├── phrog
+│   ├── MT680615.csv
+│   └── OM818327.csv
+└── seed.txt
+sub1seed2022
+├── gff
+│   ├── MT680615.gff
+│   └── OM818327.gff
+├── phrog
+│   ├── MT680615.csv
+│   └── OM818327.csv
+└── seed.txt
+subseedrandom
+├── gff
+│   ├── MH937464.gff
+│   └── MK937606.gff
+├── phrog
+│   ├── MH937464.csv
+│   └── MK937606.csv
+└── seed.txt
+```

--- a/scripts/make_subset.py
+++ b/scripts/make_subset.py
@@ -24,6 +24,9 @@ def parse_args() -> argparse.Namespace:
         type=int,
         help="amount of phrog gff pairs that a new subset should contain",
     )
+    argparser.add_argument(
+        "-s", "--seed", dest="seed", type=int, default=None, required=False
+    )
     return argparser.parse_args()
 
 
@@ -46,7 +49,6 @@ def main():
         phrogs
     ), f"can't request larger sample size than the actual phrog population = {len(phrogs)}!"
 
-    samples = random.sample(range(0, len(phrogs)), args.sample_size)
     subset_dir = Path(f"subset_of_{args.sample_size}")
 
     try:
@@ -64,6 +66,14 @@ def main():
 
     phrogs.sort()
     gffs.sort()
+
+    seed = random.randrange(sys.maxsize) if args.seed is None else args.seed
+    random.seed(seed)
+
+    with open(subset_dir / "seed.txt", "w") as f:
+        f.write(f"{seed}\n")
+
+    samples = random.sample(range(0, len(phrogs)), args.sample_size)
 
     for idx, sample in enumerate(samples, start=1):
         gff_to_copy = gffs[sample]

--- a/scripts/make_subset.py
+++ b/scripts/make_subset.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+import shutil
+import random
+import argparse
+from pathlib import Path
+import sys
+
+
+def panic(*args, **kwargs):
+    print(*args, **kwargs, file=sys.stderr)
+    sys.exit(1)
+
+
+def parse_args() -> argparse.Namespace:
+    argparser = argparse.ArgumentParser(
+        prog="make_subset",
+        description="makes dirs containing subsets of phrogs and gffs",
+        epilog="pozdro świry",
+    )
+    argparser.add_argument("phrog_dir", type=str)
+    argparser.add_argument("gff_dir", type=str)
+    argparser.add_argument(
+        "sample_size",
+        type=int,
+        help="amount of phrog gff pairs that a new subset should contain",
+    )
+    return argparser.parse_args()
+
+
+def get_dir_contents(directory):
+    try:
+        return list(directory.iterdir())
+    except NotADirectoryError:
+        panic(f"you lied about {directory} being a directory!!! :C")
+
+
+def main():
+    args = parse_args()
+    phrog_dir = Path(args.phrog_dir)
+    gff_dir = Path(args.gff_dir)
+
+    phrogs = get_dir_contents(phrog_dir)
+    gffs = get_dir_contents(gff_dir)
+    assert len(phrogs) == len(gffs), "there is different amount of phrogs ang gffs :C"
+    assert args.sample_size <= len(
+        phrogs
+    ), f"can't request larger sample size than the actual phrog population = {len(phrogs)}!"
+
+    samples = random.sample(range(0, len(phrogs)), args.sample_size)
+    subset_dir = Path(f"subset_of_{args.sample_size}")
+
+    try:
+        subset_dir.mkdir()
+    except FileExistsError:
+        panic(
+            f"such subset already exist, if you wanna another one rename {subset_dir} manually xd "
+        )
+
+    newphrogs = subset_dir / "phrog"
+    newgffs = subset_dir / "gff"
+
+    newphrogs.mkdir()
+    newgffs.mkdir()
+
+    phrogs.sort()
+    gffs.sort()
+
+    for idx, sample in enumerate(samples, start=1):
+        gff_to_copy = gffs[sample]
+        phrog_to_copy = phrogs[sample]
+
+        shutil.copy(phrog_to_copy, newphrogs / phrog_to_copy.name)
+        shutil.copy(gff_to_copy, newgffs / gff_to_copy.name)
+        print(f"\r{idx}/{args.sample_size}", end="")
+    print()
+    print(f"created: {subset_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# changes
- added scripts folder
- added scripts/make_subset.py
- added scripts/README.md
## scripts folder
the idea is we can throw some convenient scripts in there that help us
with the project; I added a scripts/README to quickly explain what scripts do;
## make_subset.py
Probably some of us will need this script to test around on a smaller subset;
usage:
```bash
/m/t/p/p/data ❯ ./make_subset.py phrog gff 420
420/420
created: subset_of_420
```

```text
/m/t/p/p/data ❯ ls subset_of_420/phrog | wc                                                                                                                                              
    420     420    5577
/m/t/p/p/data ❯ ls subset_of_420/gff | wc
    420     420    5577
```
