### PR TITLE
Exclude plots directory from languages statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+plots/* linguist-generated


### PR DESCRIPTION
# small change to improve presentation of our repo
## .gitattributes
Added .gitattributes file with instructions to exclude plots directory from our language statistics;
99.9% html looks bad and is not representive of our actual source code;
It would be nicer if an outside observer could infer at first glance that this is a python project.

## about linguist overrides
I chose linguist-generated for this case;
[overrides.md](https://github.com/github/linguist/blob/c1c34e5260797b4d598f5ec76f19723bfc5a1894/docs/overrides.md)
