### PR TITLE
small fix: change dill version requirement to 0.3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest==7.2.0
 pandas==1.1.4
 numpy==1.19.5
-dill==1.0.0
+dill==0.3.6
 alive-progress==2.4.1


### PR DESCRIPTION
#small requirements.txt fix
changed dill version from non-existing 1.0.0 to 0.3.6