### PR TITLE
Feature/faa props

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 alive_progress = "*"
-dill = "*"
+biopython = "*"
 
 [dev-packages]
 pytest = "*"

--- a/parsers/pajtonparser/pajtonparser.py
+++ b/parsers/pajtonparser/pajtonparser.py
@@ -4,8 +4,10 @@ import sys
 from pathlib import Path
 import pickle
 
+from alive_progress import alive_bar
 from numpy import inf
 from tadpole import pond
+
 
 
 argparser = argparse.ArgumentParser(
@@ -20,12 +22,9 @@ argparser.add_argument(
 argparser.add_argument(
     "-o", "--output", dest="output", help="prefix/prefix-path for output files", type=str, required=True
 )
-argparser.add_argument(
-    "-p", "--props", dest = "props", help = "which protein props to add?", type = str, required=False, default=None
-)
+
 
 group = argparser.add_mutually_exclusive_group()
-
 group.add_argument(
     "--number", dest="number", help="Add numbers to jokers?", action="store_true"
 )
@@ -33,21 +32,40 @@ group.add_argument(
     "--collapse", dest="collapse", help="Should we collapse unknown proteins into one string with prefix?", action="store_true"
 )
 
+cfg_group = argparser.add_argument_group()
+cfg_group.add_argument(
+    "-p", "--props", dest = "props", help = "props location", type = str, required=False, default=None,
+)
+cfg_group.add_argument(
+    "-c", "--config", dest = "config", help = "which protein props to add?", type = str, required=False, default=None
+)
+
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 def main():
     args = argparser.parse_args()
-
+    if (args.props and not args.config) or (not args.props and args.config):
+        raise ValueError("Props and config must always occur together")
 
     loc = pond.PondLocation(Path(args.phrog_dir), Path(args.gff_dir))
     opt = pond.PondOptions(args.distance, args.number, args.collapse)
+    props = args.props
+
+    config = None
+    if args.props:
+        with open(args.props) as fh, open(args.config) as fhc, alive_bar(title = "Prot params"):
+            props = json.load(fh)
+            config = json.load(fhc)
+        valid_cfg = {'molecular_weight', 'instability_index', 'isoelectric_point', 'gravy', 'aromaticity'}
+        if any(key not in valid_cfg for key in config):
+            raise ValueError("Config contains invalid entries")
+        if any(not isinstance(value, bool) for value in config.values()):
+            raise ValueError("Config values should be bool's only")
+        config = pond.PondConfig(props, config) 
 
     parser = pond.PondParser(loc, opt)
-
-    print("Started parsing...")
-
-    res = parser.parse()
+    res = parser.parse(pond_config = config)
 
     pickle_path = f"{args.output}.pickle"
     text_path = f"{args.output}.txt"
@@ -61,16 +79,6 @@ def main():
     print()
     print("Done processing all files.")
 
-def test():
-    args = argparser.parse_args()
-    loc = pond.PondLocation(Path(args.phrog_dir), Path(args.gff_dir))
-    opt = pond.PondOptions(args.distance, args.number, args.collapse)
-    
-    parser = pond.PondParser(loc, opt)
-    res = parser.parse_proteins(Path(args.props))
-    with open("prot_params.json", "w") as fh:
-        fh.write(json.dumps(res))
-
 if __name__ == "__main__":
     # main()
-    test()
+    main()

--- a/parsers/pajtonparser/pajtonparser.py
+++ b/parsers/pajtonparser/pajtonparser.py
@@ -1,8 +1,8 @@
 import argparse
 import json
-import dill
 import sys
 from pathlib import Path
+import pickle
 
 from numpy import inf
 from tadpole import pond
@@ -21,9 +21,15 @@ argparser.add_argument(
     "-o", "--output", dest="output", help="prefix/prefix-path for output files", type=str, required=True
 )
 argparser.add_argument(
+    "-p", "--props", dest = "props", help = "which protein props to add?", type = str, required=False, default=None
+)
+
+group = argparser.add_mutually_exclusive_group()
+
+group.add_argument(
     "--number", dest="number", help="Add numbers to jokers?", action="store_true"
 )
-argparser.add_argument(
+group.add_argument(
     "--collapse", dest="collapse", help="Should we collapse unknown proteins into one string with prefix?", action="store_true"
 )
 
@@ -32,6 +38,7 @@ def eprint(*args, **kwargs):
 
 def main():
     args = argparser.parse_args()
+
 
     loc = pond.PondLocation(Path(args.phrog_dir), Path(args.gff_dir))
     opt = pond.PondOptions(args.distance, args.number, args.collapse)
@@ -42,11 +49,11 @@ def main():
 
     res = parser.parse()
 
-    dill_path = f"{args.output}.dill"
+    pickle_path = f"{args.output}.pickle"
     text_path = f"{args.output}.txt"
     try:
-        with open(dill_path, "wb") as fh1, open(text_path, "w", encoding="utf-8") as fh2:
-            dill.dump(res, fh1)
+        with open(pickle_path, "wb") as fh1, open(text_path, "w", encoding="utf-8") as fh2:
+            pickle.dump(res, fh1)
             fh2.write(json.dumps(res))
     except TypeError:
         eprint("Dill or json serialization oofed.")
@@ -54,6 +61,16 @@ def main():
     print()
     print("Done processing all files.")
 
+def test():
+    args = argparser.parse_args()
+    loc = pond.PondLocation(Path(args.phrog_dir), Path(args.gff_dir))
+    opt = pond.PondOptions(args.distance, args.number, args.collapse)
+    
+    parser = pond.PondParser(loc, opt)
+    res = parser.parse_proteins(Path(args.props))
+    with open("prot_params.json", "w") as fh:
+        fh.write(json.dumpls(res))
 
 if __name__ == "__main__":
-    main()
+    # main()
+    test()

--- a/parsers/pajtonparser/pajtonparser.py
+++ b/parsers/pajtonparser/pajtonparser.py
@@ -58,8 +58,8 @@ def main():
             props = json.load(fh)
             config = json.load(fhc)
         valid_cfg = {'molecular_weight', 'instability_index', 'isoelectric_point', 'gravy', 'aromaticity'}
-        if any(key not in valid_cfg for key in config):
-            raise ValueError("Config contains invalid entries")
+        if any(key not in valid_cfg for key in config) or len(config) != len(valid_cfg):
+            raise ValueError("Config contains invalid entries or not all entries")
         if any(not isinstance(value, bool) for value in config.values()):
             raise ValueError("Config values should be bool's only")
         config = pond.PondConfig(props, config) 

--- a/parsers/pajtonparser/pajtonparser.py
+++ b/parsers/pajtonparser/pajtonparser.py
@@ -69,7 +69,7 @@ def test():
     parser = pond.PondParser(loc, opt)
     res = parser.parse_proteins(Path(args.props))
     with open("prot_params.json", "w") as fh:
-        fh.write(json.dumpls(res))
+        fh.write(json.dumps(res))
 
 if __name__ == "__main__":
     # main()

--- a/parsers/pajtonparser/tadpole/pond.py
+++ b/parsers/pajtonparser/tadpole/pond.py
@@ -82,6 +82,11 @@ class PondOptions:
         self.collapse = collapse
 
 @dataclass
+class PondConfig:
+    params: dict[dict[str, float]]
+    config: dict[bool]
+
+@dataclass
 class PondRecord:
     id: str
     phrogs: list[str]
@@ -157,7 +162,7 @@ class PondParser:
         return prot_props
 
 
-    def parse(self) -> list[list[str]]:
+    def parse(self, pond_config: PondConfig = None) -> list[list[str]]:
         self._fill_map()
         Sentence = list[str]
         
@@ -176,7 +181,12 @@ class PondParser:
                         strand = Strand.into(strand)
                         if not phrogs:
                             phrogs = ["joker"]
-
+                            if pond_config is not None: 
+                                params = pond_config.params.get(prot)
+                                if params:
+                                    phrogs = [
+                                        "joker_" + "|".join(f"{key}:{val :.2f}" for key, val in params.items() if pond_config.config[key])
+                                    ]
                         dist = 0 if j == 0 else start - self.records[j - 1].end
                         record = PondRecord(prot, phrogs, start, end, strand, dist)
                         self.records.append(record)
@@ -220,4 +230,3 @@ class PondParser:
             
         self.content = paragraph
         return paragraph
-        

--- a/parsers/pajtonparser/tadpole/pond.py
+++ b/parsers/pajtonparser/tadpole/pond.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from collections import defaultdict
 from enum import Enum
-from alive_progress import alive_bar, alive_it
+from alive_progress import alive_bar
 from alive_progress.animations.spinners import bouncing_spinner_factory
 from Bio import SeqIO, SeqUtils
-from Bio.SeqUtils import ProtParam, IsoelectricPoint
+from Bio.SeqUtils import ProtParam
 from threading import Thread
 
 PHROG_SPINNER = bouncing_spinner_factory(("🐸", "🐸"), 8, background = ".", hide = False, overlay =True)
@@ -83,8 +83,8 @@ class PondOptions:
 
 @dataclass
 class PondConfig:
-    params: dict[dict[str, float]]
-    config: dict[bool]
+    params: dict[dict[str, float]] # 'Protein_ID': { 'chemical_property': 'value' }
+    config: dict[bool] # 'chemical_property': True/False
 
 @dataclass
 class PondRecord:

--- a/prot_config.json
+++ b/prot_config.json
@@ -1,0 +1,7 @@
+{
+    "molecular_weight": true, 
+    "instability_index": true,
+    "isoelectric_point": true, 
+    "gravy": true, 
+    "aromaticity": true
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas==1.1.4
 numpy==1.19.5
 dill==1.0.0
 alive-progress==2.4.1
+biopython==1.80


### PR DESCRIPTION
# Properties for jokers
So I managed to write a code that adds some chemical properties to all jokers (if one could get a property for a joker). 
### Changes
Repo now contains prot_params.json (gzipped, big size) containig chemical properties for each protein (calculated using BioPython). User can provied --config and --props  files (prot_config.json and prot_params.jsonf respectively). Then for each property marked as 'true' in config, code will add this property to a joker while parsing.

### Usage example
```bash
python parsers/pajtonparser/pajtonparser.py Data/phrog/ Data/gf
f/ -o result --props prot_params.json --config prot_config.json
```

### Config example
```
{
    "molecular_weight": true, 
    "instability_index": true,
    "isoelectric_point": true, 
    "gravy": true, 
    "aromaticity": true
}
```

### Results example
```
["phrog_3", "phrog_1083", "phrog_904", "phrog_1655", "phrog_1654", "phrog_1270", "phrog_1463", "phrog_121", "joker_molecular_weight:6923.97|aromaticity:0.07|instability_index:43.12|gravy:-0.60|isoelectric_point:9.40", "phrog_1605"]
```

### Misc
I left the parse_proteins staticmethod which I used to get the chemical properties. I thought we can use it again for some purposes, so prolly it should stay untouched until we decide to release the software. Then we can refactor.