### PR TITLE
Bugfix/prefix strip

### DIFF
--- a/parsers/pajtonparser/pajtonparser.py
+++ b/parsers/pajtonparser/pajtonparser.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import pickle
 from pathlib import Path
+from datetime import datetime
 
 from alive_progress import alive_bar
 from jsonschema import validate, ValidationError
@@ -31,6 +32,8 @@ cfg_group.add_argument(
 )
 
 def main():
+    now = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+    MAIN_LOGGER.info(f"Started program at {now}:")
     args = argparser.parse_args()
 
     pond_location = pond.PondLocation(Path(args.phrog_dir), Path(args.gff_dir))

--- a/parsers/pajtonparser/tadpole/pond.py
+++ b/parsers/pajtonparser/tadpole/pond.py
@@ -311,7 +311,7 @@ class PondParser:
                     for j, line in enumerate(lines):
                         *_, start, end, _, strand, _, prot = line.split("\t")
                         start, end = int(start), int(end)
-                        prot = prot.split(";", maxsplit=1)[0].lstrip("ID=")
+                        prot = prot.split(";", maxsplit=1)[0].removeprefix("ID=")
                         phrogs = self.map[prot]
                         strand = Strand.into(strand)
                         if not phrogs:

--- a/parsers/pajtonparser/tadpole/pond.py
+++ b/parsers/pajtonparser/tadpole/pond.py
@@ -12,6 +12,7 @@ from threading import Thread
 from statistics import quantiles
 
 from .logger import POND_LOGGER
+from .utils import ProteinNotFoundError
 
 PHROG_SPINNER = bouncing_spinner_factory(("🐸", "🐸"), 8, background = ".", hide = False, overlay =True)
 
@@ -192,7 +193,8 @@ class PondParser:
                             # if protein not found
                             # Skip this protein in our word, add to logs
                             if not props:
-                                POND_LOGGER.error(f"Protein '{prot}' not found")
+                                POND_LOGGER.critical(f"Protein '{prot}' not found")
+                                raise ProteinNotFoundError(f"Protein '{prot} was not found in prot params *.json file'")
                             else : 
                                 for prop, prop_value in props.items():
                                     if not self.params.config[prop]: # If property is false
@@ -323,8 +325,8 @@ class PondParser:
                                 props = self.params.props.get(prot) # Like {molecular_weight: 6043}... etc.
                                 # if protein not found
                                 if not props: # Skip this protein in our word, add to logs
-                                    POND_LOGGER.error(f"Protein '{prot}' not found")
-                                    phrogs = ["!!!!!#####"]
+                                    POND_LOGGER.critical(f"Protein '{prot}' not found")
+                                    raise ProteinNotFoundError(f"Protein '{prot} was not found in prot params *.json file'")
                                 else:   
                                     for prop, prop_value in props.items():
                                         if not self.params.config[prop]: # If property is false

--- a/parsers/pajtonparser/tadpole/utils.py
+++ b/parsers/pajtonparser/tadpole/utils.py
@@ -1,3 +1,7 @@
+class ProteinNotFoundError(Exception):
+	pass
+
+
 CONFIG_SCHEMA = {
 	"$schema": "http://json-schema.org/draft-07/schema#", 
 	"$id": "https://example.com/object1670961194.json", 


### PR DESCRIPTION
Fixed a bug with additional letter being stripped. Changed `lstrip` to `removeprefix` fixed it. Also:
- Added additional new type of Error called `ProteinNotFoundError`
- Changed logging level from error to critical when `ProteinNotFound` exception is raised since it's not possible to recover
- Added info about program start time to logs using `datetime.now()`